### PR TITLE
Fix the deserialization of InternalConvexHull

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 17
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Check Format

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/build.gradle
+++ b/build.gradle
@@ -85,4 +85,7 @@ testClusters.configureEach {
     setting 'logger.org.elasticsearch.plugins', 'DEBUG'
     setting 'logger.org.elasticsearch.cluster', 'DEBUG'
     setting 'logger.org.elasticsearch.cluster.metadata', 'TRACE'
+
+    // uncomment to enable remote JVM debugger for local dev
+    // jvmArgs "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5007"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 es_version = 8.19.6
-plugin_version = 8.19.6.0
+plugin_version = 8.19.6.1

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/metric/InternalConvexHull.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/metric/InternalConvexHull.java
@@ -118,6 +118,7 @@ public class InternalConvexHull extends InternalNumericMetricsAggregation.MultiV
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteable(format);
         if (convexHull != null) {
             out.writeInt(convexHull.getCoordinates().length);
             for (Coordinate coord : convexHull.getCoordinates()) {

--- a/src/yamlRestTest/resources/rest-api-spec/test/EnvelopeAggregation/20_envelope_aggregation.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/EnvelopeAggregation/20_envelope_aggregation.yml
@@ -22,7 +22,7 @@ setup:
 
   - do:
       indices.refresh:
-        index: [test_index]
+        index: test_index
 
   - do:
       search:
@@ -105,7 +105,7 @@ setup:
             - 45
   - do:
       indices.refresh:
-        index: [test_index]
+        index: test_index
 
   - do:
       search:
@@ -120,7 +120,6 @@ setup:
   - match: { hits.total: 3 }
   - match: { aggregations.envelope.convex_hull.type: Polygon }
   - match: { aggregations.envelope.convex_hull.coordinates: [[[45.0, 45.0], [49.99999995343387, 49.99999999534339], [49.99999995343387, 45.0], [45.0, 45.0]]]}
-
 
 ---
 "Test aggregation on three points plus an inner point":
@@ -158,7 +157,7 @@ setup:
             - 46
   - do:
       indices.refresh:
-        index: [test_index]
+        index: test_index
 
   - do:
       search:
@@ -173,3 +172,52 @@ setup:
   - match: { hits.total: 4 }
   - match: { aggregations.envelope.convex_hull.type: Polygon }
   - match: { aggregations.envelope.convex_hull.coordinates: [[[45.0, 45.0], [49.99999995343387, 49.99999999534339], [49.99999995343387, 45.0], [45.0, 45.0]]]}
+
+---
+"Test internal shards serializers / deserializer by running the same query twice, hence calling the request cache":
+  - do:
+      create:
+        index: test_index
+        id: 1
+        body:
+          point:
+            - 45
+            - 45
+
+  - do:
+      indices.refresh:
+        index: test_index
+
+  - do:
+      indices.put_settings:
+        index: test_index
+        body:
+          index:
+            requests.cache.enable: true
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          size: 0
+          aggs:
+            envelope:
+              envelope:
+                field: point
+
+  - match: { hits.total: 1 }
+
+  # Second strictly identical search is hitting the cache
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          size: 0
+          aggs:
+            envelope:
+              envelope:
+                field: point
+
+  - match: { hits.total: 1 }


### PR DESCRIPTION
The goal of this PR is to fix the deserialization of InternalConvexHull, which has been broken since the 8.x upgrade due to an internal Elasticsearch breaking change. The change caused InternalNumericMetricsAggregation to expect a DocValue optional format at the end of the StreamOutput during serialization.

## Reproduce the issue
Install the fixed plugin: 
[envelope-aggregation-8.19.6.1-fix.zip](https://github.com/user-attachments/files/23623750/envelope-aggregation-8.19.6.1.zip)


Just play the base scenario from the README, but run the last query twice. It will crash because the second query will try to read the agg result from the cache, resulting in an internal SteamInput deserialization which will crash with:
```
[2025-11-18T17:08:05,187][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [runTask-0] fatal error in thread [elasticsearch[runTask-0][search][T#3]], exiting java.lang.AssertionError: Unknown NamedWriteable [org.elasticsearch.search.DocValueFormat][]
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.NamedWriteableRegistry.throwOnUnknownWritable(NamedWriteableRegistry.java:150)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.NamedWriteableRegistry.getReader(NamedWriteableRegistry.java:126)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.NamedWriteableRegistry.getReader(NamedWriteableRegistry.java:109)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:56)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:33)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation.<init>(InternalNumericMetricsAggregation.java:147)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation.<init>(InternalNumericMetricsAggregation.java:137)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation$MultiValue.<init>(InternalNumericMetricsAggregation.java:90)
        at org.opendatasoft.elasticsearch.search.aggregations.metric.InternalConvexHull.<init>(InternalConvexHull.java:110)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteableCollectionAsList(NamedWriteableAwareStreamInput.java:46)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.aggregations.InternalAggregations.readFrom(InternalAggregations.java:172)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.DelayableWriteable.deserialize(DelayableWriteable.java:236)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.io.stream.DelayableWriteable.referencing(DelayableWriteable.java:61)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.query.QuerySearchResult.readFromWithId(QuerySearchResult.java:432)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.query.QuerySearchResult.readFromWithId(QuerySearchResult.java:402)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.indices.IndicesService.loadIntoContext(IndicesService.java:1622)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.SearchService.loadOrExecuteQueryPhase(SearchService.java:650)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.SearchService.executeQueryPhase(SearchService.java:824)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.search.SearchService.lambda$executeQueryPhase$6(SearchService.java:688)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:79)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:76)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.action.ActionRunnable$4.doRun(ActionRunnable.java:101)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:34)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1044)
        at org.elasticsearch.server@8.19.6/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
        at java.base/java.lang.Thread.run(Thread.java:1447)
```
